### PR TITLE
Return null if date column value is null

### DIFF
--- a/src/PersianDateTrait.php
+++ b/src/PersianDateTrait.php
@@ -29,6 +29,11 @@ trait PersianDateTrait {
     public function convertToPersian($what = 'created_at', $format = null)
     {
         $format = is_null($format) ? $this->getJalaliFormat() : $format;
+        
+        if (is_null($this->$what)) {
+            return null;
+        }
+        
         return jDate::forge($this->$what)->format($format);
     }
 


### PR DESCRIPTION
When the date column value e.g. `deleted_at` is null, it would convert it today date in Jalali.
Here check for value of the colu
